### PR TITLE
Feature/8 update courses

### DIFF
--- a/lib/daigaku/course.rb
+++ b/lib/daigaku/course.rb
@@ -6,7 +6,7 @@ module Daigaku
     def initialize(path)
       @path = path
       @title = File.basename(path).gsub(/\_+/, ' ')
-      @author = QuickStore.store.get("courses/#{store_key}/author")
+      @author = QuickStore.store.get(key(:author))
     end
 
     def chapters
@@ -21,8 +21,8 @@ module Daigaku
       chapters.reduce(true) { |mastered, chapter| mastered &&= chapter.mastered? }
     end
 
-    def store_key
-      title.downcase.gsub(' ', '_')
+    def key(key_name)
+      Storeable.key(title, prefix: 'courses', suffix: key_name)
     end
   end
 end

--- a/lib/daigaku/course.rb
+++ b/lib/daigaku/course.rb
@@ -6,6 +6,7 @@ module Daigaku
     def initialize(path)
       @path = path
       @title = File.basename(path).gsub(/\_+/, ' ')
+      @author = QuickStore.store.get("courses/#{store_key}/author")
     end
 
     def chapters
@@ -18,6 +19,10 @@ module Daigaku
 
     def mastered?
       chapters.reduce(true) { |mastered, chapter| mastered &&= chapter.mastered? }
+    end
+
+    def store_key
+      title.downcase.gsub(' ', '_')
     end
   end
 end

--- a/lib/daigaku/github_client.rb
+++ b/lib/daigaku/github_client.rb
@@ -1,0 +1,28 @@
+require 'open-uri'
+require 'json'
+require 'date'
+
+module Daigaku
+  module GithubClient
+
+    # Returns the url to the master zip file of the Github repo.
+    def self.master_zip_url(user_and_repo)
+      "https://github.com/#{user_and_repo}/archive/master.zip"
+    end
+
+    # Returns the timestamp of pushed_at for the repo from the Github API.
+    def self.pushed_at(user_and_repo)
+      url = "https://api.github.com/repos/#{user_and_repo}"
+      JSON.parse(open(url).read)['pushed_at']
+    end
+
+    # Returns whether the pushed_at time from Github API is newer than the
+    # stored one.
+    def self.updated?(user_and_repo)
+      course = Course.new(user_and_repo.split('/').last)
+      stored_time = QuickStore.get(course.key(:pushed_at))
+      current_time = self.pushed_at(user_and_repo)
+      DateTime.parse(stored_time) < DateTime.parse(current_time)
+    end
+  end
+end

--- a/lib/daigaku/github_client.rb
+++ b/lib/daigaku/github_client.rb
@@ -10,10 +10,10 @@ module Daigaku
       "https://github.com/#{user_and_repo}/archive/master.zip"
     end
 
-    # Returns the timestamp of pushed_at for the repo from the Github API.
-    def self.pushed_at(user_and_repo)
+    # Returns the timestamp of updated_at for the repo from the Github API.
+    def self.updated_at(user_and_repo)
       url = "https://api.github.com/repos/#{user_and_repo}"
-      JSON.parse(open(url).read)['pushed_at']
+      JSON.parse(open(url).read)['updated_at']
     end
 
     # Returns whether the pushed_at time from Github API is newer than the
@@ -23,7 +23,7 @@ module Daigaku
 
       course = Course.new(user_and_repo.split('/').last)
       stored_time = QuickStore.store.get(course.key(:updated_at))
-      current_time = self.pushed_at(user_and_repo)
+      current_time = self.updated_at(user_and_repo)
       DateTime.parse(stored_time) < DateTime.parse(current_time)
     end
   end

--- a/lib/daigaku/github_client.rb
+++ b/lib/daigaku/github_client.rb
@@ -20,7 +20,7 @@ module Daigaku
     # stored one.
     def self.updated?(user_and_repo)
       course = Course.new(user_and_repo.split('/').last)
-      stored_time = QuickStore.get(course.key(:pushed_at))
+      stored_time = QuickStore.store.get(course.key(:pushed_at))
       current_time = self.pushed_at(user_and_repo)
       DateTime.parse(stored_time) < DateTime.parse(current_time)
     end

--- a/lib/daigaku/github_client.rb
+++ b/lib/daigaku/github_client.rb
@@ -19,8 +19,10 @@ module Daigaku
     # Returns whether the pushed_at time from Github API is newer than the
     # stored one.
     def self.updated?(user_and_repo)
+      return false unless user_and_repo
+
       course = Course.new(user_and_repo.split('/').last)
-      stored_time = QuickStore.store.get(course.key(:pushed_at))
+      stored_time = QuickStore.store.get(course.key(:updated_at))
       current_time = self.pushed_at(user_and_repo)
       DateTime.parse(stored_time) < DateTime.parse(current_time)
     end

--- a/lib/daigaku/solution.rb
+++ b/lib/daigaku/solution.rb
@@ -23,15 +23,20 @@ module Daigaku
     end
 
     def store_key
-      @store_key ||= build_store_key('verified')
+      unless @store_key
+        part_path = path.split('/')[-3..-1].join('/').gsub(FILE_SUFFIX, '')
+        @store_key = Storeable.key(part_path, prefix: 'verified')
+      end
+
+      @store_key
     end
 
     private
 
     def solution_path(path)
       local_path = Daigaku.config.solutions_path
-      sub_dirs = path.split('/')[-3..-2].map { |part| clean_up_path_part(part) }
-      file = clean_up_path_part(File.basename(path)) + FILE_SUFFIX
+      sub_dirs = Storeable.key(path.split('/')[-3..-2].join('/').gsub(FILE_SUFFIX, ''))
+      file = Storeable.key(File.basename(path)) + FILE_SUFFIX
 
       File.join(local_path, sub_dirs, file)
     end
@@ -43,17 +48,6 @@ module Daigaku
 
     def get_store_state
       QuickStore.store.get(store_key)
-    end
-
-    def build_store_key(prefix = nil)
-      parts = @path.split('/')[-3..-1].map { |part| clean_up_path_part(part) }
-      [prefix, *parts].compact.join('/')
-    end
-
-    def clean_up_path_part(text)
-      leading_numbers = /(^\d+[\_\-\s]|#{FILE_SUFFIX})/
-      part_joints = /[\_\-\s]+/
-      text.gsub(leading_numbers, '').gsub(part_joints, '_').downcase
     end
   end
 end

--- a/lib/daigaku/storeable.rb
+++ b/lib/daigaku/storeable.rb
@@ -4,18 +4,29 @@ module Daigaku
     LEADING_NUMBERS = /^\d+[\_\-\s]+/
     PART_JOINTS = /[\_\-\s]+/
 
-    def self.key(text, options = {})
-      separator = QuickStore.config.key_separator
-      prefix = options[:prefix]
-      suffix = clean(options[:suffix])
-      suffixes = options[:suffixes]
-      suffixes_items = suffixes ? suffixes.map { |s| clean(s) }.compact : nil
+    class << self
+      def key(text, options = {})
+        separator = QuickStore.config.key_separator
+        prefix = options[:prefix]
+        suffix = clean(options[:suffix])
+        suffixes = options[:suffixes]
+        suffixes_items = suffixes ? suffixes.map { |s| clean(s) }.compact : nil
 
-      [prefix, clean(text), suffix || suffixes_items].compact.join(separator)
+        [prefix, clean(text), suffix || suffixes_items].compact.join(separator)
+      end
+
+      private
+
+      def clean(text)
+        if text
+          parts = text.to_s.split(QuickStore.config.key_separator).map do |key|
+            key.gsub(LEADING_NUMBERS, '').gsub(PART_JOINTS, '_').downcase
+          end
+
+          parts.join(QuickStore.config.key_separator)
+        end
+      end
     end
 
-    def self.clean(text)
-      text.gsub(LEADING_NUMBERS, '').gsub(PART_JOINTS, '_').downcase if text
-    end
   end
 end

--- a/lib/daigaku/storeable.rb
+++ b/lib/daigaku/storeable.rb
@@ -1,0 +1,21 @@
+module Daigaku
+  module Storeable
+
+    LEADING_NUMBERS = /^\d+[\_\-\s]+/
+    PART_JOINTS = /[\_\-\s]+/
+
+    def self.key(text, options = {})
+      separator = QuickStore.config.key_separator
+      prefix = options[:prefix]
+      suffix = clean(options[:suffix])
+      suffixes = options[:suffixes]
+      suffixes_items = suffixes ? suffixes.map { |s| clean(s) }.compact : nil
+
+      [prefix, clean(text), suffix || suffixes_items].compact.join(separator)
+    end
+
+    def self.clean(text)
+      text.gsub(LEADING_NUMBERS, '').gsub(PART_JOINTS, '_').downcase if text
+    end
+  end
+end

--- a/lib/daigaku/terminal/courses.rb
+++ b/lib/daigaku/terminal/courses.rb
@@ -77,8 +77,8 @@ module Daigaku
         author = parts.first
         course = parts.second
 
-        key = Storeable.key(course, prefix: 'courses', suffix: 'author')
-        QuickStore.store.set(key, author)
+        course = Course.new(course)
+        QuickStore.store.set(course.key(:author), author)
       end
 
       def unzip(file_path, github = false)

--- a/lib/daigaku/terminal/courses.rb
+++ b/lib/daigaku/terminal/courses.rb
@@ -28,6 +28,8 @@ module Daigaku
         url_given = (url =~ /\A#{URI::regexp(['http', 'https'])}\z/)
         github = use_initial_course || options[:github] || url.match(/github\.com/)
 
+        store_author(options[:github]) if github
+
         raise Download::NoUrlError unless url_given
         raise Download::NoZipFileUrlError unless File.basename(url) =~ /\.zip/
 
@@ -68,6 +70,15 @@ module Daigaku
 
       def github_repo(user_and_repo)
         "https://github.com/#{user_and_repo}/archive/master.zip"
+      end
+
+      def store_author(user_and_repo)
+        parts = (user_and_repo ||= Daigaku.config.initial_course).split('/')
+        author = parts.first
+        course = parts.second
+
+        key = Storeable.key(course, prefix: 'courses', suffix: 'author')
+        QuickStore.store.set(key, author)
       end
 
       def unzip(file_path, github = false)

--- a/lib/daigaku/views/courses_menu.rb
+++ b/lib/daigaku/views/courses_menu.rb
@@ -42,7 +42,7 @@ module Daigaku
 
         non_empty_courses.map do |course|
           line = "#{course.title}"
-          self.items_info = self.items_info << (course.author ? "(by #{course.author})" : '')
+          self.items_info <<= [(course.author ? "(by #{course.author})" : '')]
           line
         end
       end

--- a/lib/daigaku/views/courses_menu.rb
+++ b/lib/daigaku/views/courses_menu.rb
@@ -42,7 +42,7 @@ module Daigaku
 
         non_empty_courses.map do |course|
           line = "#{course.title}"
-          line << "(#{course.author})" if course.author
+          self.items_info = self.items_info << (course.author ? "(by #{course.author})" : '')
           line
         end
       end

--- a/lib/daigaku/views/menu.rb
+++ b/lib/daigaku/views/menu.rb
@@ -53,6 +53,8 @@ module Daigaku
           window.print_indicator(models[index])
           window.attrset(index == active_index ? A_STANDOUT : A_NORMAL)
           window.write " #{item.to_s} "
+          window.attrset(A_NORMAL)
+          window.write " #{items_info[index].to_s}"
         end
 
         window.refresh
@@ -72,6 +74,14 @@ module Daigaku
 
       def header_text
         raise "Please implement the method #header_text!"
+      end
+
+      def items_info
+        @items_info || []
+      end
+
+      def items_info=(items_info)
+        @items_info = items_info
       end
     end
 

--- a/lib/daigaku/views/menu.rb
+++ b/lib/daigaku/views/menu.rb
@@ -54,7 +54,7 @@ module Daigaku
           window.attrset(index == active_index ? A_STANDOUT : A_NORMAL)
           window.write " #{item.to_s} "
           window.attrset(A_NORMAL)
-          window.write " #{items_info[index].to_s}"
+          window.write " #{items_info[index].join(' ')}"
         end
 
         window.refresh

--- a/lib/daigaku/views/menu.rb
+++ b/lib/daigaku/views/menu.rb
@@ -54,7 +54,7 @@ module Daigaku
           window.attrset(index == active_index ? A_STANDOUT : A_NORMAL)
           window.write " #{item.to_s} "
           window.attrset(A_NORMAL)
-          window.write " #{items_info[index].join(' ')}"
+          window.write " #{items_info[index].try(:join, ' ')}"
         end
 
         window.refresh

--- a/spec/daigaku/course_spec.rb
+++ b/spec/daigaku/course_spec.rb
@@ -72,4 +72,20 @@ describe Daigaku::Course do
       expect(subject.mastered?).to be false
     end
   end
+
+  describe "#store_key" do
+    it "returns the underscored, downcased title of the course" do
+      expect(subject.store_key).to eq subject.title.gsub(' ', '_').downcase
+    end
+  end
+
+  describe "#author" do
+    it "returns the author of Github courses form the store" do
+      author = 'author'
+      QuickStore.store.set("courses/#{subject.store_key}/author", author)
+
+      course = Daigaku::Course.new(course_path)
+      expect(course.author).to eq author
+    end
+  end
 end

--- a/spec/daigaku/course_spec.rb
+++ b/spec/daigaku/course_spec.rb
@@ -73,16 +73,18 @@ describe Daigaku::Course do
     end
   end
 
-  describe "#store_key" do
-    it "returns the underscored, downcased title of the course" do
-      expect(subject.store_key).to eq subject.title.gsub(' ', '_').downcase
+  describe "#key" do
+    it "returns the courses store key for the given key name" do
+      allow(subject).to receive(:title) { '1-Course title' }
+      key = "courses/course_title/some_key"
+      expect(subject.key('1-some Key')).to eq key
     end
   end
 
   describe "#author" do
     it "returns the author of Github courses form the store" do
       author = 'author'
-      QuickStore.store.set("courses/#{subject.store_key}/author", author)
+      QuickStore.store.set(subject.key(:author), author)
 
       course = Daigaku::Course.new(course_path)
       expect(course.author).to eq author

--- a/spec/daigaku/github_client_spec.rb
+++ b/spec/daigaku/github_client_spec.rb
@@ -37,12 +37,12 @@ describe Daigaku::GithubClient do
     end
 
     it "returns true if content was pushed to the Github repo" do
-      allow(QuickStore).to receive(:get) { |key| "2015-10-21T11:59:59Z" }
+      QuickStore.store.set('courses/b/pushed_at', "2015-10-21T11:59:59Z")
       expect(Daigaku::GithubClient.updated?('a/b')).to be_truthy
     end
 
     it "returns false if no content was pushed to the Github repo" do
-      allow(QuickStore).to receive(:get) { |key| @received_timestamp }
+      QuickStore.store.set('courses/b/pushed_at', @received_timestamp)
       expect(Daigaku::GithubClient.updated?('a/b')).to be_falsey
     end
   end

--- a/spec/daigaku/github_client_spec.rb
+++ b/spec/daigaku/github_client_spec.rb
@@ -37,13 +37,17 @@ describe Daigaku::GithubClient do
     end
 
     it "returns true if content was pushed to the Github repo" do
-      QuickStore.store.set('courses/b/pushed_at', "2015-10-21T11:59:59Z")
+      QuickStore.store.set('courses/b/updated_at', "2015-10-21T11:59:59Z")
       expect(Daigaku::GithubClient.updated?('a/b')).to be_truthy
     end
 
     it "returns false if no content was pushed to the Github repo" do
-      QuickStore.store.set('courses/b/pushed_at', @received_timestamp)
+      QuickStore.store.set('courses/b/updated_at', @received_timestamp)
       expect(Daigaku::GithubClient.updated?('a/b')).to be_falsey
+    end
+
+    it "returns false if param is nil" do
+      expect(Daigaku::GithubClient.updated?(nil)).to be_falsey
     end
   end
 end

--- a/spec/daigaku/github_client_spec.rb
+++ b/spec/daigaku/github_client_spec.rb
@@ -9,17 +9,17 @@ describe Daigaku::GithubClient do
     end
   end
 
-  describe "#pushed_at" do
-    it "fetches the pushed_at timestamp from the Github API" do
+  describe "#updated_at" do
+    it "fetches the updated_at timestamp from the Github API" do
       expected_timestamp = "2015-10-21T12:00:00Z"
-      response = { pushed_at: expected_timestamp }.to_json
+      response = { updated_at: expected_timestamp }.to_json
       url = "https://api.github.com/repos/a/b"
 
       stub_request(:get, url)
         .with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' })
         .to_return(status: 200, body: response, headers: {})
 
-      timestamp = Daigaku::GithubClient.pushed_at('a/b')
+      timestamp = Daigaku::GithubClient.updated_at('a/b')
 
       expect(timestamp).to eq expected_timestamp
     end
@@ -28,7 +28,7 @@ describe Daigaku::GithubClient do
   describe "#updated?" do
     before do
       @received_timestamp = "2015-10-21T12:00:00Z"
-      response = { pushed_at: @received_timestamp }.to_json
+      response = { updated_at: @received_timestamp }.to_json
       url = "https://api.github.com/repos/a/b"
 
       stub_request(:get, url)

--- a/spec/daigaku/github_client_spec.rb
+++ b/spec/daigaku/github_client_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe Daigaku::GithubClient do
+
+  describe "#master_zip_url" do
+    it "returns the url to the master zip file for the given github repo" do
+      url = "https://github.com/a/b/archive/master.zip"
+      expect(Daigaku::GithubClient.master_zip_url('a/b')).to eq url
+    end
+  end
+
+  describe "#pushed_at" do
+    it "fetches the pushed_at timestamp from the Github API" do
+      expected_timestamp = "2015-10-21T12:00:00Z"
+      response = { pushed_at: expected_timestamp }.to_json
+      url = "https://api.github.com/repos/a/b"
+
+      stub_request(:get, url)
+        .with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' })
+        .to_return(status: 200, body: response, headers: {})
+
+      timestamp = Daigaku::GithubClient.pushed_at('a/b')
+
+      expect(timestamp).to eq expected_timestamp
+    end
+  end
+
+  describe "#updated?" do
+    before do
+      @received_timestamp = "2015-10-21T12:00:00Z"
+      response = { pushed_at: @received_timestamp }.to_json
+      url = "https://api.github.com/repos/a/b"
+
+      stub_request(:get, url)
+        .with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' })
+        .to_return(status: 200, body: response, headers: {})
+    end
+
+    it "returns true if content was pushed to the Github repo" do
+      allow(QuickStore).to receive(:get) { |key| "2015-10-21T11:59:59Z" }
+      expect(Daigaku::GithubClient.updated?('a/b')).to be_truthy
+    end
+
+    it "returns false if no content was pushed to the Github repo" do
+      allow(QuickStore).to receive(:get) { |key| @received_timestamp }
+      expect(Daigaku::GithubClient.updated?('a/b')).to be_falsey
+    end
+  end
+end

--- a/spec/daigaku/storeable_spec.rb
+++ b/spec/daigaku/storeable_spec.rb
@@ -7,9 +7,14 @@ describe Daigaku::Storeable do
   end
 
   describe '::key' do
-    it "creates a store key out of the given string" do
+    it "creates a store key from the given string" do
       key = Daigaku::Storeable.key('1-_Raw content-Title')
       expect(key).to eq 'raw_content_title'
+    end
+
+    it "creates a cleaned up store key from a given path string" do
+      key = Daigaku::Storeable.key('path/to/the/1-_Raw content string')
+      expect(key).to eq 'path/to/the/raw_content_string'
     end
 
     it "creates a prefixed key when a prefix option is given" do

--- a/spec/daigaku/storeable_spec.rb
+++ b/spec/daigaku/storeable_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Daigaku::Storeable do
+
+  it "responds to ::key" do
+    expect(Daigaku::Storeable).to respond_to :key
+  end
+
+  describe '::key' do
+    it "creates a store key out of the given string" do
+      key = Daigaku::Storeable.key('1-_Raw content-Title')
+      expect(key).to eq 'raw_content_title'
+    end
+
+    it "creates a prefixed key when a prefix option is given" do
+      key = Daigaku::Storeable.key('1-_Raw content-Title', prefix: 'courses')
+      expect(key).to eq 'courses/raw_content_title'
+    end
+
+    it "creates a suffixed key if a suffix option is given" do
+      key = Daigaku::Storeable.key('1-_Raw content-Title', suffix: '1-author')
+      expect(key).to eq 'raw_content_title/author'
+    end
+
+    it "creates a multi suffixed key if a suffixes option is given" do
+      key = Daigaku::Storeable.key('1-_Raw content-Title', suffixes: ['meta', '1-author'] )
+      expect(key).to eq 'raw_content_title/meta/author'
+    end
+  end
+end

--- a/spec/daigaku/terminal/courses_spec.rb
+++ b/spec/daigaku/terminal/courses_spec.rb
@@ -28,6 +28,10 @@ describe Daigaku::Terminal::Courses do
           'User-Agent' => 'Ruby'
           })
         .to_return(status: 200, body: @file_content, headers: {})
+
+      stub_request(:get, "https://api.github.com/repos/daigaku-ruby/Get_started_with_Ruby")
+        .with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' })
+        .to_return(status: 200, body: "{}", headers: {})
     end
 
     after { cleanup_download(@zip_file_name) }
@@ -54,10 +58,45 @@ describe Daigaku::Terminal::Courses do
     end
 
     it "stores the course's author for courses from Github" do
-      subject.download('https://github.com/daigaku-ruby/Get_started_with_Ruby')
-      store_key = 'courses/get_started_with_ruby/author'
+      url = "https://github.com/user/repo/archive/master.zip"
 
-      expect(QuickStore.store.get(store_key)).to eq 'daigaku-ruby'
+      stub_request(:get, url)
+        .with(headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'User-Agent' => 'Ruby'
+          })
+        .to_return(status: 200, body: @file_content, headers: {})
+
+      stub_request(:get, "https://api.github.com/repos/user/repo")
+        .with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' })
+        .to_return(status: 200, body: "{}", headers: {})
+
+      subject.download(url)
+      store_key = 'courses/repo/author'
+
+      expect(QuickStore.store.get(store_key)).to eq 'user'
+    end
+
+    it "stores the course's repo for courses from Github" do
+      url = "https://github.com/user/repo/archive/master.zip"
+
+      stub_request(:get, url)
+        .with(headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'User-Agent' => 'Ruby'
+          })
+        .to_return(status: 200, body: @file_content, headers: {})
+
+      stub_request(:get, "https://api.github.com/repos/user/repo")
+        .with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' })
+        .to_return(status: 200, body: "{}", headers: {})
+
+      subject.download(url)
+      store_key = 'courses/repo/github'
+
+      expect(QuickStore.store.get(store_key)).to eq 'user/repo'
     end
   end
 

--- a/spec/daigaku/terminal/courses_spec.rb
+++ b/spec/daigaku/terminal/courses_spec.rb
@@ -38,10 +38,7 @@ describe Daigaku::Terminal::Courses do
 
     it "creates a new courses folder in the daigaku courses directory" do
       target_path = File.join(Daigaku.config.courses_path, File.basename(course_dirs.first))
-
       dirs = Dir[File.join(Daigaku.config.courses_path, '**')]
-      puts "target_path: #{target_path}"
-      puts dirs.to_s
 
       expect(dirs.include?(target_path)).to be_truthy
     end
@@ -54,6 +51,13 @@ describe Daigaku::Terminal::Courses do
     it "raises an error if param is no url to a zip file" do
       expect(subject).to receive(:say_warning)
       subject.download('http://exmaple.com/something-else')
+    end
+
+    it "stores the course's author for courses from Github" do
+      subject.download('https://github.com/daigaku-ruby/Get_started_with_Ruby')
+      store_key = 'courses/get_started_with_ruby/author'
+
+      expect(QuickStore.store.get(store_key)).to eq 'daigaku-ruby'
     end
   end
 

--- a/spec/daigaku/terminal/courses_spec.rb
+++ b/spec/daigaku/terminal/courses_spec.rb
@@ -42,7 +42,6 @@ describe Daigaku::Terminal::Courses do
     it "creates a new courses folder in the daigaku courses directory" do
       target_path = File.join(Daigaku.config.courses_path, File.basename(course_dirs.first))
       dirs = Dir[File.join(Daigaku.config.courses_path, '**')]
-
       expect(dirs.include?(target_path)).to be_truthy
     end
 
@@ -56,72 +55,78 @@ describe Daigaku::Terminal::Courses do
       subject.download('http://exmaple.com/something-else')
     end
 
-    it "stores the course's author for courses from Github" do
-      url = "https://github.com/user/repo/archive/master.zip"
+    describe "stores download data:" do
+      before do
+        @github_url = "https://github.com/user/course_a/archive/master.zip"
 
-      stub_request(:get, url)
-        .with(headers: {
-          'Accept' => '*/*',
-          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'User-Agent' => 'Ruby'
-          })
-        .to_return(status: 200, body: @file_content, headers: {})
+        stub_request(:get, @github_url)
+          .with(headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'User-Agent' => 'Ruby'
+            })
+          .to_return(status: 200, body: @file_content, headers: {})
 
-      stub_request(:get, "https://api.github.com/repos/user/repo")
-        .with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' })
-        .to_return(status: 200, body: "{}", headers: {})
+        stub_request(:get, "https://api.github.com/repos/course_a/repo")
+          .with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' })
+          .to_return(status: 200, body: "{}", headers: {})
+      end
 
-      subject.download(url)
-      store_key = 'courses/repo/author'
+      it "stores the course's author for courses from Github" do
+        subject.download(@github_url)
+        store_key = 'courses/course_a/author'
+        expect(QuickStore.store.get(store_key)).to eq 'user'
+      end
 
-      expect(QuickStore.store.get(store_key)).to eq 'user'
-    end
+      it "stores the course's repo for courses from Github" do
+        subject.download(@github_url)
+        store_key = 'courses/course_a/github'
+        expect(QuickStore.store.get(store_key)).to eq 'user/course_a'
+      end
 
-    it "stores the course's repo for courses from Github" do
-      url = "https://github.com/user/repo/archive/master.zip"
+      it "stores the downloading timestamp" do
+        time = Time.now
+        allow(Time).to receive(:now) { time }
+        subject.download(@url)
+        expect(QuickStore.store.get('courses/course_a/updated_at')).to eq time.to_s
+      end
 
-      stub_request(:get, url)
-        .with(headers: {
-          'Accept' => '*/*',
-          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'User-Agent' => 'Ruby'
-          })
-        .to_return(status: 200, body: @file_content, headers: {})
-
-      stub_request(:get, "https://api.github.com/repos/user/repo")
-        .with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' })
-        .to_return(status: 200, body: "{}", headers: {})
-
-      subject.download(url)
-      store_key = 'courses/repo/github'
-
-      expect(QuickStore.store.get(store_key)).to eq 'user/repo'
-    end
-
-    it "stores the downloading timestamp" do
-      time = Time.now
-      allow(Time).to receive(:now) { time }
-
-      subject.download(@url)
-      expect(QuickStore.store.get('courses/course_a/updated_at')).to eq time.to_s
-    end
-
-    it "stores the course's download url" do
-      subject.download(@url)
-      expect(QuickStore.store.get('courses/course_a/url')).to eq @url
+      it "stores the course's download url" do
+        subject.download(@url)
+        expect(QuickStore.store.get('courses/course_a/url')).to eq @url
+      end
     end
   end
 
   describe '#update' do
     before do
+      Daigaku.config.courses_path = local_courses_path
+
+      @zip_file_name = "repo.zip"
+      @file_content = prepare_download(@zip_file_name)
+      @url = "https://example.com/#{@zip_file_name}"
+
+      stub_request(:get, @url)
+        .with(headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'User-Agent' => 'Ruby'
+          })
+        .to_return(status: 200, body: @file_content, headers: {})
+
+      stub_request(:get, "https://api.github.com/repos/daigaku-ruby/Get_started_with_Ruby")
+        .with(headers: { 'Accept' => '*/*', 'User-Agent' => 'Ruby' })
+        .to_return(status: 200, body: "{}", headers: {})
+
       allow(subject).to receive(:download) { true }
-      allow(Daigaku::GithubClient).to receive(:updated?) { true }
+      allow(Daigaku::GithubClient).to receive(:updated?) { |attr| true }
     end
+
+    after { cleanup_download(@zip_file_name) }
 
     it "updates a course that is not from Github on each call" do
       url = 'https://example.com/repo.zip'
       expect(subject).to receive(:download).with(url, 'updated').once
-
       subject.update('Course_A')
     end
 

--- a/spec/support/macros/resource_helpers.rb
+++ b/spec/support/macros/resource_helpers.rb
@@ -33,7 +33,9 @@ module ResourceHelpers
 
     Zip::File.open(zip_file_path, Zip::File::CREATE) do |zip_file|
       Dir[File.join(directory, '**', '**')].each do |file|
-        zip_file.add(file.sub(directory, '')[1..-1], file) { true }
+        if file.match(course_dir_names.first)
+          zip_file.add(file.sub(directory, '')[1..-1], file) { true }
+        end
       end
     end
 


### PR DESCRIPTION
* Fixes #8.
* Adds a `daigaku courses update` command to the CLI.
* `url` and `updated_at` timestamp for each course is stored on download.
* Github repo short (user/repo-name) is stored on download as `github`.
* Timestamp is used to only update courses from Github if there is new content on master.
* Author for courses from Github are shown in the courses menu (partly solves #7).

A course's data is stored in QuickStore under the `courses` prefix, like:
```
...
courses:
  get_started_with_ruby:
    author: daigaku-ruby
    github: daigaku-ruby/Get_started_with_Ruby
    url: https://github.com/daigaku-ruby/Get_started_with_Ruby/archive/master.zip
    updated_at: '2015-04-18 14:53:44 +0200'
```  