### PR TITLE
Fix ruby-doc markdown parsing of scoped and stdlib classes

### DIFF
--- a/lib/daigaku/markdown.rb
+++ b/lib/daigaku/markdown.rb
@@ -1,0 +1,1 @@
+require 'daigaku/markdown/ruby_doc'

--- a/lib/daigaku/markdown/ruby_doc.rb
+++ b/lib/daigaku/markdown/ruby_doc.rb
@@ -1,0 +1,90 @@
+require 'cgi'
+
+module Daigaku
+  class Markdown
+    class RubyDoc
+
+      RUBY_DOC_URL    = "http://ruby-doc.org".freeze
+      CORE_BASE_URL   = "#{RUBY_DOC_URL}/core-#{RUBY_VERSION}".freeze
+      STDLIB_BASE_URL = "#{RUBY_DOC_URL}/stdlib-#{RUBY_VERSION}".freeze
+
+      CORE_REGEX      = /\(ruby-doc core:\s?(.*)\)/.freeze
+      STDLIB_REGEX    = /\(ruby-doc stdlib:\s?(.*)\)/.freeze
+
+      class << self
+        def parse(text)
+          case text
+          when CORE_REGEX
+            core_link(text.match(CORE_REGEX).captures.first)
+          when STDLIB_REGEX
+            stdlib_link(text.match(STDLIB_REGEX).captures.first)
+          end
+        end
+
+        def core_link(text)
+          new.core_link(text)
+        end
+
+        def stdlib_link(text)
+          new.stdlib_link(text)
+        end
+      end
+
+      def core_link(text)
+        constants = ruby_constants(text).join('/')
+        method = ruby_method(text)
+
+        "#{CORE_BASE_URL}/#{constants}.html#{method}"
+      end
+
+      def stdlib_link(text)
+        constants = ruby_constants(text).join('/')
+        method = ruby_method(text)
+        libdoc_part = "libdoc/#{ruby_stdlib(text)}/rdoc"
+
+        "#{STDLIB_BASE_URL}/#{libdoc_part}/#{constants}.html#{method}"
+      end
+
+      private
+
+      # Returns the stdlib part of the url.
+      # If an explicit stdlib name is defined in markdown, e.g.
+      #   (ruby-doc stdlib: net/http Net::HTTP) => 'net/http'
+      # then this lib name is used.
+      # Else the lib is created from the constants, e.g.
+      #   (ruby-doc stdlib: Time) => 'time'
+      def ruby_stdlib(text)
+        parts = text.split(' ')
+
+        if parts.length > 1
+          parts.first.strip.downcase
+        else
+          ruby_constants(text).join('/').downcase
+        end
+      end
+
+      def ruby_constants(text)
+        parts = text.split(' ').last.split(/::|#/)
+        select_capitalized(parts)
+      end
+
+      def ruby_method(text)
+        method = text.split(/::|#/).last
+        return '' unless downcased?(method)
+
+        method_type = text.match(/#/) ? 'i' : 'c'
+        method_name = CGI.escape(method.strip).gsub('%', '-').gsub(/\A-/, '')
+        "#method-#{method_type}-#{method_name}"
+      end
+
+      def select_capitalized(parts)
+        parts.select { |part| part[0] == part[0].upcase }
+      end
+
+      def downcased?(text)
+        text == text.downcase
+      end
+
+    end
+  end
+end

--- a/spec/daigaku/markdown/ruby_doc_spec.rb
+++ b/spec/daigaku/markdown/ruby_doc_spec.rb
@@ -1,0 +1,103 @@
+require 'spec_helper'
+
+describe Daigaku::Markdown::RubyDoc do
+
+  [:core_link, :stdlib_link, :parse].each do |class_method|
+    it "responds to #{class_method}" do
+      expect(Daigaku::Markdown::RubyDoc).to respond_to class_method
+    end
+  end
+
+  it { is_expected.to respond_to :core_link }
+  it { is_expected.to respond_to :stdlib_link }
+
+  def parse(text)
+    Daigaku::Markdown::RubyDoc.parse(text)
+  end
+
+  describe '::parse' do
+    context 'for a text containing a core doc markup' do
+      let(:base_url) { "http://ruby-doc.org/core-#{RUBY_VERSION}" }
+
+      it 'returns the right link for a single class' do
+        markdown = '(ruby-doc core: String)'
+        expect(parse(markdown)).to eq "#{base_url}/String.html"
+      end
+
+      it 'returns the right link for a single namespaced class' do
+        markdown = '(ruby-doc core: Enumerator::Lazy)'
+        expect(parse(markdown)).to eq "#{base_url}/Enumerator/Lazy.html"
+      end
+
+      it 'returns the right link for a multi namespaced class' do
+        markdown = '(ruby-doc core: Thread::Backtrace::Location)'
+        expect(parse(markdown)).to eq "#{base_url}/Thread/Backtrace/Location.html"
+      end
+
+      it "returns the right link for a single class's class method" do
+        markdown = '(ruby-doc core: String::new)'
+        expect(parse(markdown)).to eq "#{base_url}/String.html#method-c-new"
+      end
+
+      it "returns the right link for a single class's instance method" do
+        markdown = '(ruby-doc core: String#count)'
+        expect(parse(markdown)).to eq "#{base_url}/String.html#method-i-count"
+      end
+
+      it "returns the right link for a namespaced class's class method" do
+        markdown = '(ruby-doc core: Enumerator::Lazy::new)'
+        expect(parse(markdown)).to eq "#{base_url}/Enumerator/Lazy.html#method-c-new"
+      end
+
+      it "returns the right link for a namespaced class's instance method" do
+        markdown = '(ruby-doc core: Enumerator::Lazy#flat_map)'
+        expect(parse(markdown)).to eq "#{base_url}/Enumerator/Lazy.html#method-i-flat_map"
+      end
+
+    end
+
+    context 'for a text containing a stdlib doc markup' do
+      let(:base_url) { "http://ruby-doc.org/stdlib-#{RUBY_VERSION}/libdoc" }
+
+      it 'returns the right link for a single class' do
+        markdown = '(ruby-doc stdlib: Time)'
+        expect(parse(markdown)).to eq "#{base_url}/time/rdoc/Time.html"
+      end
+
+      it 'returns the right link for a single class with an explicit lib' do
+        markdown = '(ruby-doc stdlib: date Time)'
+        expect(parse(markdown)).to eq "#{base_url}/date/rdoc/Time.html"
+      end
+
+      it 'returns the right link for a single namespaced class' do
+        markdown = '(ruby-doc stdlib: Net::HTTP)'
+        expect(parse(markdown)).to eq "#{base_url}/net/http/rdoc/Net/HTTP.html"
+      end
+
+      it 'returns the right link for a multi namespaced class' do
+        markdown = '(ruby-doc stdlib: json JSON::Ext::Generator::State)'
+        expect(parse(markdown)).to eq "#{base_url}/json/rdoc/JSON/Ext/Generator/State.html"
+      end
+
+      it "returns the right link for a single class's class method" do
+        markdown = '(ruby-doc stdlib: Time::parse)'
+        expect(parse(markdown)).to eq "#{base_url}/time/rdoc/Time.html#method-c-parse"
+      end
+
+      it "returns the right link for a single class's instance method" do
+        markdown = '(ruby-doc stdlib: Time#httpdate)'
+        expect(parse(markdown)).to eq "#{base_url}/time/rdoc/Time.html#method-i-httpdate"
+      end
+
+      it "returns the right link for a namespaced class's class method" do
+        markdown = '(ruby-doc stdlib: Net::HTTP::get)'
+        expect(parse(markdown)).to eq "#{base_url}/net/http/rdoc/Net/HTTP.html#method-c-get"
+      end
+
+      it "returns the right link for a namespaced class's instance method" do
+        markdown = '(ruby-doc stdlib: Net::HTTP#get)'
+        expect(parse(markdown)).to eq "#{base_url}/net/http/rdoc/Net/HTTP.html#method-i-get"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #27.

* Use character case to distinguish constants and method
* Allow defining the stdlib name before classes/methods  
  e.g. `(ruby-doc stdlib: date Time#to_date)`  
  If lib name is not given, the constant part is used to build the url  
  e.g. `(ruby-doc stdlib: Net::HTTP)`