### PR TITLE
Show error message on verfification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: ruby
+
+before_install:
+  - gem update --system
+  - gem install bundler
+
 rvm:
   - 2.0.0
   - 2.2.0

--- a/lib/daigaku/test_result.rb
+++ b/lib/daigaku/test_result.rb
@@ -59,7 +59,7 @@ module Daigaku
         examples: [
           {
             status: 'failed',
-            exception: { message: ":( You got a syntax error in your code!" }
+            exception: { message: ":( You got an error in your code!" }
           }
         ]
       }

--- a/lib/daigaku/views/task_view.rb
+++ b/lib/daigaku/views/task_view.rb
@@ -186,7 +186,7 @@ module Daigaku
 
       def print_test_results(window)
         result = @unit.solution.verify!
-        @test_result_lines = result.summary_lines
+        @test_result_lines = test_result_lines(result)
 
         if result.passed?
           code_lines = @unit.reference_solution.code_lines
@@ -213,6 +213,22 @@ module Daigaku
         initialize_window(height)
       end
 
+      def test_result_lines(result)
+        lines  = result.summary_lines
+        lines += code_error_lines(@unit.solution.code) unless result.passed?
+        lines
+      end
+
+      def code_error_lines(code)
+        begin
+          eval(code)
+        rescue Exception => e
+          return e.inspect.gsub(/(^.*#<|>.*$)/, '').lines.map(&:rstrip)
+        end
+
+        []
+      end
+
       def reset_screen(window)
         @test_result_lines = nil
         @lines = @unit.task.markdown.lines
@@ -228,7 +244,7 @@ module Daigaku
       end
 
       def example_index(heights, index)
-        heights.values.index { |range| range.include?(index) }
+        heights.values.index { |range| range.include?(index) }.to_i
       end
     end
 


### PR DESCRIPTION
If there are errors in the user‘s solution code, instead of just saying "You got an error in your code!" the concrete Error message is now shown in the Task View.

E.g.: 

```
failed: :( You got an error in your code!
NoMethodError: undefined method `conca' for "Ruby":String
``` 
```
failed: :( You got an error in your code!
SyntaxError: (eval):1: unterminated string meets end of file
```