### PR TITLE
Handle interrupt of CLI

### DIFF
--- a/bin/daigaku
+++ b/bin/daigaku
@@ -6,7 +6,11 @@ begin
   require 'daigaku'
 rescue LoadError => e
   warn "could not load \"daigaku\"\n#{e}"
-  exit -1
+  exit(-1)
 end
 
-Daigaku::Terminal::CLI.start
+begin
+  Daigaku::Terminal::CLI.start
+rescue Interrupt
+  puts "\n\n\t👋 See you soon!"
+end

--- a/lib/daigaku/terminal/cli.rb
+++ b/lib/daigaku/terminal/cli.rb
@@ -9,6 +9,8 @@ module Daigaku
     class CLI < Thor
       include Terminal::Output
 
+      package_name 'Daigaku'
+
       desc 'courses [COMMAND]', 'Handle daigaku courses'
       subcommand 'courses', Terminal::Courses
 


### PR DESCRIPTION
…to not see the full stacktrace when closing daigaku with e.g. `Ctrl+C`.